### PR TITLE
Remove extra output line in cli

### DIFF
--- a/wally-cli/Program.cs
+++ b/wally-cli/Program.cs
@@ -57,7 +57,6 @@ namespace CLI
                     }
                 });
                 spinner.Text = "Keyboard flashed, enjoy your new firmware.";
-                spinner.Text = $"{device.HidHandle.DefaultReportId}";
             });
         }
         static void PrintUsage()


### PR DESCRIPTION
Remove line in cli code that was not needed and would cause null reference exceptions for some device types.