### PR TITLE
Use parenthetical plural on log statement

### DIFF
--- a/Wally/Models/StateViewModel.cs
+++ b/Wally/Models/StateViewModel.cs
@@ -17,7 +17,7 @@ namespace Wally.Models
         private Device _selectedDevice;
         private void Flash()
         {
-            Logger.Log(LogSeverity.Info, $"Starting flash process, targeting {Target} devices.");
+            Logger.Log(LogSeverity.Info, $"Starting flash process, targeting {Target} device(s).");
             Task.Run(async () =>
             {
                 try


### PR DESCRIPTION
The log "Starting flash process, targeting 1 devices.", for example, has a grammatical error. The word "devices" should not be in plural form. Proposing to use a parenthetical plural to let the user decide how it should be read.